### PR TITLE
fix: pin Azure AKS node pools to single zone to prevent Managed Disk AZ mismatch

### DIFF
--- a/terraform/azure/main.tf
+++ b/terraform/azure/main.tf
@@ -131,6 +131,8 @@ resource "azurerm_kubernetes_cluster" "qualytics" {
 ################################################################################
 # Application Node Pool
 # For: API, Frontend, PostgreSQL, RabbitMQ, Spark Operator, Cert-Manager
+# Pinned to a single zone to prevent Azure Managed Disk AZ mismatch:
+# Managed Disks are zone-locked, so replacement nodes must come up in the same zone.
 ################################################################################
 
 resource "azurerm_kubernetes_cluster_node_pool" "app" {
@@ -139,6 +141,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "app" {
   vm_size               = var.app_node_vm_size
   vnet_subnet_id        = azurerm_subnet.aks.id
   os_disk_size_gb       = var.app_node_os_disk_size_gb
+  zones                 = [var.node_group_az]
 
   auto_scaling_enabled = true
   min_count            = var.app_node_min_count
@@ -164,6 +167,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "driver" {
   vm_size               = var.driver_node_vm_size
   vnet_subnet_id        = azurerm_subnet.aks.id
   os_disk_size_gb       = var.driver_node_os_disk_size_gb
+  zones                 = [var.node_group_az]
 
   auto_scaling_enabled = true
   min_count            = var.driver_node_min_count
@@ -190,6 +194,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "executor" {
   vm_size               = var.executor_node_vm_size
   vnet_subnet_id        = azurerm_subnet.aks.id
   os_disk_size_gb       = var.executor_node_os_disk_size_gb
+  zones                 = [var.node_group_az]
 
   auto_scaling_enabled = true
   min_count            = var.executor_node_min_count

--- a/terraform/azure/terraform.tfvars.example
+++ b/terraform/azure/terraform.tfvars.example
@@ -55,6 +55,10 @@ api_server_authorized_ip_ranges = []
 # AKS SKU tier (Free or Standard). Standard recommended for production SLA.
 sku_tier = "Standard"
 
+# Availability zone to pin all node pools to (e.g. '1', '2', '3')
+# Prevents Azure Managed Disk zone mismatch when nodes are recycled into a different zone
+node_group_az = "1"
+
 #-------------------------------------------------------------------------------
 # Application Nodes
 # For: API, Frontend, PostgreSQL, RabbitMQ, Spark Operator, Cert-Manager

--- a/terraform/azure/variables.tf
+++ b/terraform/azure/variables.tf
@@ -82,6 +82,12 @@ variable "sku_tier" {
   default     = "Standard"
 }
 
+variable "node_group_az" {
+  description = "Availability zone to pin node pools to (e.g. '1', '2', '3'). Prevents Azure Managed Disk zone mismatch when nodes are recycled into a different zone."
+  type        = string
+  default     = "1"
+}
+
 #-------------------------------------------------------------------------------
 # Application Node Pool Configuration
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
Azure Managed Disks are zone-locked. Without zone pinning, a recycled node can come up in a different zone than its existing PVCs, causing FailedScheduling errors. 