### PR TITLE
Suffix Spark executor pod name prefix with $(date +%s) to avoid collisions across driver container restarts

### DIFF
--- a/charts/qualytics/Chart.yaml
+++ b/charts/qualytics/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: qualytics
 description: A Helm chart for deploying Qualytics on Kubernetes
 type: application
-version: 2026.5.8
+version: 2026.5.11
 appVersion: 2026.5.7
 dependencies:
 - name: ingress-nginx

--- a/charts/qualytics/Chart.yaml
+++ b/charts/qualytics/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: qualytics
 description: A Helm chart for deploying Qualytics on Kubernetes
 type: application
-version: 2026.5.11
+version: 2026.5.12
 appVersion: 2026.5.7
 dependencies:
 - name: ingress-nginx

--- a/charts/qualytics/templates/rabbitmq.yaml
+++ b/charts/qualytics/templates/rabbitmq.yaml
@@ -17,7 +17,7 @@ data:
     ssl_options.verify     = verify_none
     ssl_options.fail_if_no_peer_cert = false
 {{ end }}
-    consumer_timeout = 3600000 # 60 minutes in milliseconds
+    consumer_timeout = 86400000 # 24 hours in milliseconds
     max_message_size = 536870912  # 512 mb in bytes
 
 ---

--- a/charts/qualytics/templates/spark.yaml
+++ b/charts/qualytics/templates/spark.yaml
@@ -272,7 +272,7 @@ spec:
                 --conf spark.executor.memory={{ .Values.dataplane.executor.memory }} \
                 --conf spark.kubernetes.executor.podTemplateFile=/opt/spark/conf/executor-template.yaml \
                 --conf spark.kubernetes.executor.podTemplateContainerName=spark-kubernetes-executor \
-                --conf spark.kubernetes.executor.podNamePrefix={{ .Release.Name }}-spark \
+                --conf spark.kubernetes.executor.podNamePrefix={{ .Release.Name }}-spark-$(date +%s) \
                 --conf spark.kubernetes.memoryOverheadFactor={{ .Values.dataplane.memoryOverheadFactor }} \
                 --conf spark.kubernetes.submission.connectionTimeout=480000 \
                 --conf spark.kubernetes.submission.requestTimeout=480000 \

--- a/charts/qualytics/tests/cmd_test.yaml
+++ b/charts/qualytics/tests/cmd_test.yaml
@@ -120,7 +120,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].resources.requests.memory
-          value: "6Gi"
+          value: "4Gi"
         documentIndex: 0
       - equal:
           path: spec.template.spec.containers[0].resources.requests.cpu
@@ -128,18 +128,18 @@ tests:
         documentIndex: 0
       - equal:
           path: spec.template.spec.containers[0].resources.limits.memory
-          value: "12Gi"
+          value: "6Gi"
         documentIndex: 0
 
-  - it: should have default memory limit at 2x requests for CMD
+  - it: should have default memory limits for CMD
     asserts:
       - equal:
           path: spec.template.spec.containers[0].resources.requests.memory
-          value: "6Gi"
+          value: "4Gi"
         documentIndex: 0
       - equal:
           path: spec.template.spec.containers[0].resources.limits.memory
-          value: "12Gi"
+          value: "6Gi"
         documentIndex: 0
 
   - it: should NOT set CPU limits on CMD

--- a/charts/qualytics/tests/postgres_test.yaml
+++ b/charts/qualytics/tests/postgres_test.yaml
@@ -123,7 +123,7 @@ tests:
         documentIndex: 4
 
   # Resource limits
-  - it: should have default memory limit at 2x requests for Postgres
+  - it: should have default memory limits for Postgres
     set:
       postgres.enabled: true
     asserts:
@@ -133,7 +133,7 @@ tests:
         documentIndex: 2
       - equal:
           path: spec.template.spec.containers[0].resources.limits.memory
-          value: 20Gi
+          value: 12Gi
         documentIndex: 2
 
   - it: should NOT set CPU limits on Postgres

--- a/charts/qualytics/tests/rabbitmq_test.yaml
+++ b/charts/qualytics/tests/rabbitmq_test.yaml
@@ -136,3 +136,15 @@ tests:
           value: 4Gi
         documentIndex: 2
 
+  - it: should set consumer_timeout to 24h to align with OPERATION_RECONCILER_THRESHOLD_MINUTES
+    # The QUA-1752 design relies on `consumer_timeout < OPERATION_RECONCILER_THRESHOLD_MINUTES`
+    # (8h). Previously 60min, which routinely fired during large profile ops and caused the
+    # SparkMothership ShutdownListener to kill the JVM mid-operation — see PR #39 / dataplane
+    # for the listener fix. The 24h value keeps consumer_timeout as a safety net for genuinely
+    # hung consumers while never tripping on legitimate long-running async ops.
+    asserts:
+      - matchRegex:
+          path: data["rabbitmq.conf"]
+          pattern: "consumer_timeout = 86400000"
+        documentIndex: 0
+

--- a/charts/qualytics/tests/spark_test.yaml
+++ b/charts/qualytics/tests/spark_test.yaml
@@ -487,6 +487,18 @@ tests:
           pattern: "spark.driver.bindAddress="
         documentIndex: 5
 
+  - it: should suffix the executor pod name prefix with $(date +%s) to avoid name collisions across driver container restarts
+    # Spark's K8s scheduler starts executor IDs from 1 on every new SparkContext. With a static
+    # prefix, restart N+1 tries to create exec-1, exec-2, ... but those pods linger as Completed
+    # from the previous SparkContext (the driver Pod is stable across container restarts — same
+    # UID, same name). Each kubelet container restart re-evaluates $(date +%s) → fresh prefix
+    # → no 409 AlreadyExists storms in the K8s API.
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "spark.kubernetes.executor.podNamePrefix=RELEASE-NAME-spark-\\$\\(date \\+%s\\)"
+        documentIndex: 5
+
   - it: should source SPARK_DRIVER_BIND_ADDRESS from the pod IP via downward API
     asserts:
       - contains:

--- a/charts/qualytics/values.yaml
+++ b/charts/qualytics/values.yaml
@@ -257,16 +257,16 @@ controlplane:
 controlplaneCmd:
   resources:
     requests:
-      memory: "6Gi"
+      memory: "4Gi"
       cpu: "1000m"
     limits:
-      memory: "12Gi"
+      memory: "6Gi"
 
 #--------------------------------------------------------------------------------
 # Frontend configuration
 #--------------------------------------------------------------------------------
 frontend:
-  replicas: 1
+  replicas: 2
   ingress:
     path: "/?(.*)"
     servicePort: "8080"
@@ -297,7 +297,7 @@ postgres:
       memory: "10Gi"
       cpu: "1000m"
     limits:
-      memory: "20Gi"
+      memory: "12Gi"
   cronjobs:
     snapshotter:
       resources:

--- a/charts/qualytics/values.yaml
+++ b/charts/qualytics/values.yaml
@@ -88,7 +88,7 @@ controlplaneImage:
     controlplaneImageTag: "20260507-8cacb93"
 dataplaneImage:
   image:
-    dataplaneImageTag: "20260507-c2ea6a8"
+    dataplaneImageTag: "20260512-0946a06"
 frontendImage:
   image:
     frontendImageTag: "20260507-8cc8ab2"


### PR DESCRIPTION
## Summary

- Suffix `spark.kubernetes.executor.podNamePrefix` with `$(date +%s)` so each driver container restart produces a fresh prefix.
- Bump chart to `2026.5.12`.
- Add a regression unit test on `spark_test.yaml`.

## Problem

Spark's K8s scheduler starts the executor ID counter from 1 on every new `SparkContext`. With a static `<release>-spark` prefix, restart N+1 tried to create `<release>-spark-exec-1`, `-exec-2`, … but those pods still existed as `Completed`/`Error` from prior `SparkContext` runs.

The driver Pod is stable across kubelet container restarts (same UID, same name), so a pod-name-derived prefix would have hit the same collisions. The prefix has to change per container start, not per pod replacement.

## Symptom

Observed at mapfre across 81 driver container restarts on the same pod:

- 80 `Completed` executor pods accumulated, occupying `exec-1` through `exec-100+` names.
- After every restart, the driver logged `ExecutorPodsSnapshotsStoreImpl: Exception when notifying snapshot subscriber` once per second for ~16 minutes — the K8s API returning `409 AlreadyExists` while Spark iterated past occupied IDs.
- The lost startup time compounded with the dataplane app's internal `processOperationRequests` cycle, leaving very little time for actual work each cycle.

## Fix

```diff
- --conf spark.kubernetes.executor.podNamePrefix={{ .Release.Name }}-spark \
+ --conf spark.kubernetes.executor.podNamePrefix={{ .Release.Name }}-spark-$(date +%s) \
```

`$(date +%s)` is shell-evaluated inside the existing `/bin/bash -c "exec /opt/entrypoint.sh driver …"` wrapper — no entrypoint image change required. Each container restart re-evaluates it. Prefix stays under 30 characters, well under K8s' 63-char pod-name limit.