### PR TITLE
Add Envoy Gateway (Gateway API) as an alternative ingress to nginx

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,10 +34,11 @@ qualytics-self-hosted/
     │   ├── postgres.yaml               # PostgreSQL statefulset + PVC
     │   ├── rabbitmq.yaml               # RabbitMQ statefulset + PVC
     │   ├── secrets.yaml                # Secrets for credentials
-    │   ├── ingress.yaml                # Ingress with WAF (TLS is BYO Secret)
+    │   ├── ingress.yaml                # nginx Ingress with WAF (TLS is BYO Secret)
+    │   ├── gateway.yaml                # Envoy Gateway path: Gateway + HTTPRoutes + EG policy CRDs (alt to nginx)
     │   ├── psql.yaml                   # PostgreSQL utility pod
     │   └── storage-classes.yaml        # Platform-specific storage classes
-    └── tests/                          # Helm unit tests (9 test suites)
+    └── tests/                          # Helm unit tests (one suite per component)
         ├── api_test.yaml               # API deployment tests
         ├── cmd_test.yaml               # CMD processor tests
         ├── spark_test.yaml             # Spark application tests
@@ -45,6 +46,8 @@ qualytics-self-hosted/
         ├── postgres_test.yaml          # PostgreSQL statefulset tests
         ├── rabbitmq_test.yaml          # RabbitMQ tests
         ├── secrets_test.yaml           # Secrets configuration tests
+        ├── ingress_test.yaml           # nginx Ingress tests
+        ├── gateway_test.yaml           # Envoy Gateway (Gateway API) tests
         ├── templates_test.yaml         # Template helpers tests
         └── global_test.yaml            # Global configuration tests
 ```
@@ -81,7 +84,7 @@ This chart uses **helm-unittest** plugin for comprehensive unit testing:
 
 ### Test Structure
 - **Location**: `/charts/qualytics/tests/*_test.yaml` files
-- **Coverage**: 9 test suites covering all major components
+- **Coverage**: one suite per component (incl. `ingress_test.yaml` and `gateway_test.yaml`)
 - **Framework**: YAML-based assertions with helm-unittest plugin
 - **Installation**: `helm plugin install https://github.com/helm-unittest/helm-unittest`
 
@@ -94,6 +97,8 @@ Each component has a corresponding test file:
 - `postgres_test.yaml` - PostgreSQL statefulset tests
 - `rabbitmq_test.yaml` - RabbitMQ tests
 - `secrets_test.yaml` - Secrets configuration tests
+- `ingress_test.yaml` - nginx Ingress tests (incl. modsecurity-snippet apostrophe ban)
+- `gateway_test.yaml` - Envoy Gateway tests (route order, TLS, redirect, rate limit, mutual-exclusion guard)
 - `templates_test.yaml` - Template helper function tests
 - `global_test.yaml` - Global configuration tests
 
@@ -559,6 +564,19 @@ The dataplane image's `/opt/entrypoint.sh` does load-bearing setup before `spark
   - `/api/?(.*)` → API service
   - `/?(.*)` → Frontend service
 
+### Ingress alternative: Envoy Gateway (Gateway API)
+
+The chart can expose the app through **Envoy Gateway** instead of nginx — `templates/gateway.yaml`, gated on `gateway.enabled` (default `false`). nginx and Envoy Gateway are **mutually exclusive** (`ingress.enabled` vs `gateway.enabled`; a `fail` guard enforces it; keep `nginx.enabled: false` when using Envoy Gateway). The goal is to eventually retire nginx in favour of Envoy Gateway.
+
+- **Controller is a cluster PREREQUISITE, not a chart dependency.** Helm cannot install a CRD and a CR of it in one release (verified on minikube: the one-shot bundled install fails with `ensure CRDs are installed first`). nginx avoids this only because `Ingress` is a built-in API. So the Envoy Gateway controller + CRDs + `GatewayClass` are installed **separately** (gateway-helm standalone, e.g. a Terraform `helm_release` add-on on dedicated clusters); the chart renders only the gateway routing CRs against the pre-existing CRDs. `gateway.className` (default `eg`) references the prereq-created class; the chart does NOT create the GatewayClass or the controller. See docs/gateway-migration.md.
+- **Self-contained config.** The gateway path reads only `gateway.*` — it does NOT reuse any `ingress.*` / `nginx.*` values (so nginx can be deleted once everyone migrates). `gateway.tls.secretName` (default `qualytics-tls-cert`), `gateway.cors`, and `gateway.rateLimit.{requestsPerSecond,frontendRequestsPerSecond,burstMultiplier}` are its own. Security headers, gzip+brotli, X-Original-URI, retries and 3600s timeouts are baked in (no per-feature toggles, like nginx bakes its annotations).
+- **Resources rendered**: `Gateway` (HTTPS-terminate + HTTP-redirect listeners + `infrastructure.parametersRef` → EnvoyProxy), `HTTPRoute` ×3 (`<rel>-api` with the streaming-regex rule ordered before `/api`; `<rel>-frontend` with `/.well-known`→API keeping the frontend rate-limit policy, and `/`→frontend; `<rel>-redirect`), per-route `BackendTrafficPolicy` (retry / timeouts / rate limit / compression), `EnvoyProxy` (always — data-plane pod scheduling/replicas via `gateway.proxy.*`), and `SecurityPolicy` (CORS, only when `gateway.cors: true`). The controller, CRDs, and `GatewayClass` are NOT rendered (prerequisite).
+- **No WAF rendered.** Envoy Gateway has no native WAF; the chart intentionally does not render one (would need a BYO Coraza wasm artifact). It's a documented manual `EnvoyExtensionPolicy` add-on (the `common.modsecurity.snippet` helper still holds the rules) — a known gap vs the nginx ModSecurity path.
+- **Pod scheduling.** Controller pods are scheduled where you install gateway-helm (prereq, e.g. its own `deployment.pod.*` values in the Terraform add-on). Data-plane Envoy pods: `gateway.proxy.{replicas,nodeSelector,tolerations}` (rendered into the EnvoyProxy CRD), default `replicas: 1`.
+- **GA vs experimental.** Routing/TLS/redirect/header/timeout pieces are Gateway API GA. All `gateway.envoyproxy.io` policy CRDs are `v1alpha1` (experimental) — `helm unittest`/`helm template` validate rendering only; **validate on a live Envoy Gateway ≥ v1.8 controller** (minikube ritual) before shipping. Requires Gateway API v1.2+ (HTTPRoute timeouts).
+- **Cannot migrate 1:1** (see [docs/gateway-migration.md](docs/gateway-migration.md)): per-IP *connection* limit, native WAF + body-size limits (not rendered — manual Coraza add-on), compression content-type allow-list, burst-queue shaping, portable 308 redirect (defaults to 301), true per-IP rate limit without controller-side Redis.
+- **Helpers**: `common.modsecurity.snippet` (shared SecLang in `_helpers.tpl`, used by the nginx path + the manual gateway WAF add-on), `qualytics.gateway.routeFilters` (per-rule security headers + X-Original-URI, always emitted). Full report + live-validation checklist: [docs/gateway-migration.md](docs/gateway-migration.md).
+
 ### Storage Classes
 - **Creation**: Optional (controlled by `storageClass.create`)
 - **Custom Name**: Use `storageClass.name` to specify existing storage class
@@ -637,7 +655,8 @@ The dataplane image's `/opt/entrypoint.sh` does load-bearing setup before `spark
 - **Version**: date-based (`YYYY.M.D`) — bump on every change.
 - **App Version**: same as chart version.
 - **Dependencies**:
-  1. ingress-nginx 4.15.1 (condition: `nginx.enabled`)
+  1. ingress-nginx 4.15.1 (alias `nginx`, condition: `nginx.enabled`)
+  - NOTE: the Envoy Gateway controller is intentionally NOT a dependency — Helm can't install CRDs and CRs of them in one release, so it's a cluster prerequisite (gateway-helm installed separately). See the Envoy Gateway section.
 
 ## Authentication Configuration
 
@@ -776,6 +795,7 @@ helm upgrade qualytics qualytics/qualytics \
 - Verify driver SA can manage executor pods: `kubectl auth can-i create pods --as=system:serviceaccount:qualytics:qualytics-spark -n qualytics` should return `yes`
 
 ## Recent Focus Areas
+- Envoy Gateway (Gateway API) ingress path: `templates/gateway.yaml` renders Gateway + HTTPRoutes + Envoy Gateway policy CRDs as a `gateway.enabled` alternative to nginx (mutually exclusive), against a BYO `GatewayClass`. See the "Ingress alternative" section and [docs/gateway-migration.md](docs/gateway-migration.md).
 - Native-Deployment dataplane: replaced the SparkApplication CRD + spark-operator with a chart-managed Deployment + RBAC + headless Service + executor pod template ConfigMap. Driver runs `spark-submit` in client mode and creates executor pods directly via the K8s API.
 - Spark pod-template migration (disabled the mutating admission webhook) — historical, superseded by the above
 - cert-manager removal (BYO TLS Secrets)

--- a/README.md
+++ b/README.md
@@ -241,6 +241,14 @@ kubectl get ingress -n qualytics
 
 Note this IP address as it's needed for the next step!
 
+> **Exposing traffic via Envoy Gateway instead of nginx.** If your cluster already runs
+> an [Envoy Gateway](https://gateway.envoyproxy.io) controller, the chart can render
+> Gateway API resources (`Gateway` + `HTTPRoute` + Envoy Gateway policies) instead of the
+> nginx `Ingress` objects. Set `ingress.enabled: false`, `nginx.enabled: false`, and
+> `gateway.enabled: true` (with `gateway.className`). See
+> [docs/gateway-migration.md](./docs/gateway-migration.md) for the full
+> migration matrix and the behaviours that cannot be reproduced 1:1.
+
 ### 4. Configure DNS and TLS for your deployment
 
 Run Qualytics under a domain you control:

--- a/charts/qualytics/Chart.yaml
+++ b/charts/qualytics/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: qualytics
 description: A Helm chart for deploying Qualytics on Kubernetes
 type: application
-version: 2026.6.24
-appVersion: 2026.6.24
+version: 2026.6.30
+appVersion: 2026.6.30
 dependencies:
 - name: ingress-nginx
   version: 4.15.1

--- a/charts/qualytics/templates/_helpers.tpl
+++ b/charts/qualytics/templates/_helpers.tpl
@@ -58,6 +58,69 @@ Input shape: dataplane.driver.memory expressed in Spark units like "55000m" (= M
 {{- end -}}
 
 {{/*
+ModSecurity / Coraza SecLang snippet shared by the nginx ingress
+(templates/ingress.yaml) and the Envoy Gateway WAF (templates/gateway.yaml).
+MUST stay apostrophe-free: ingress-nginx wraps it in `modsecurity_rules '...'`, so
+any `'` (even in a comment) breaks the nginx reload. See tests/ingress_test.yaml.
+*/}}
+{{- define "common.modsecurity.snippet" -}}
+# Enable prevention mode. Can be any of: DetectionOnly,On,Off (default is DetectionOnly)
+SecRuleEngine On
+SecRequestBodyAccess On
+# Update config to include PUT/PATCH/DELETE in the allowed HTTP methods
+SecAction "id:900200,phase:1,nolog,pass,t:none,\
+  setvar:tx.allowed_methods=GET HEAD POST OPTIONS PUT PATCH DELETE"
+# Send ModSecurity audit logs to the stdout (only for rejected requests)
+SecAuditLog /dev/stdout
+SecAuditLogParts ABCIJDEFHZ
+SecAuditLogFormat JSON
+SecAuditEngine RelevantOnly # could be On/Off/RelevantOnly
+# addresses SC-14854 expanded (phase:1 to reject before body processing)
+SecRule REQUEST_URI_RAW "@rx (?:/\?){3,}" "id:14854,phase:1,deny,status:403"
+# Block absurdly long URIs used in DDoS path-traversal floods (>4KB).
+# t:length must run before @gt so the numeric comparison is against the URI
+# character count, otherwise @gt coerces the raw string to int (=0) and never fires.
+SecRule REQUEST_URI_RAW "@gt 4096" "id:14855,phase:1,deny,status:414,t:length"
+# addresses SC-15205
+SecRuleRemoveById 949110
+{{- end -}}
+
+{{/*
+Per-rule HTTPRoute filters applied to every Envoy Gateway route: the 7 security
+response headers (ResponseHeaderModifier) + the X-Original-URI request header
+(RequestHeaderModifier). Gateway API has no route-wide filter, so this block is
+included on each rule. Always emitted (the nginx path bakes the equivalents into
+its annotations). Header values are byte-identical to the nginx path.
+*/}}
+{{- define "qualytics.gateway.routeFilters" -}}
+- type: ResponseHeaderModifier
+  responseHeaderModifier:
+    set:
+      - name: X-Frame-Options
+        value: "SAMEORIGIN"
+      - name: X-Content-Type-Options
+        value: "nosniff"
+      - name: Referrer-Policy
+        value: "same-origin"
+      - name: Strict-Transport-Security
+        value: "max-age=31536000; includeSubDomains; preload"
+      - name: Content-Security-Policy
+        value: "default-src https: blob: data: 'unsafe-eval' 'unsafe-inline'; worker-src https: blob:"
+      - name: Permissions-Policy
+        value: "autoplay=(self),cross-origin-isolated=(self),display-capture=(self),encrypted-media=(self),fullscreen=(self),keyboard-map=(self),picture-in-picture=(self),publickey-credentials-get=(self),screen-wake-lock=(self),sync-xhr=(self)"
+      - name: X-Xss-Protection
+        value: "1; mode=block"
+- type: RequestHeaderModifier
+  requestHeaderModifier:
+    set:
+      # nginx: proxy_set_header X-Original-URI $request_uri. %REQ(...)% is an Envoy
+      # Gateway command-operator extension; on HTTP/1 this is the full request-target
+      # (path+query), matching $request_uri.
+      - name: X-Original-URI
+        value: "%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%"
+{{- end -}}
+
+{{/*
 Comma-separated spark.local.dir paths, one per dataplane.numVolumes.
 Renders empty when numVolumes <= 0.
 */}}

--- a/charts/qualytics/templates/gateway.yaml
+++ b/charts/qualytics/templates/gateway.yaml
@@ -1,0 +1,309 @@
+{{/*
+=============================================================================
+Envoy Gateway (Gateway API) ingress path — alternative to templates/ingress.yaml
+(nginx). Rendered only when gateway.enabled=true. Self-contained: reads only
+gateway.* (no ingress.* / nginx.* reuse).
+
+PREREQUISITE: the Envoy Gateway controller + CRDs + GatewayClass must already exist
+(installed separately, e.g. a Terraform add-on). The chart renders only the routing
+CRs below against the pre-existing CRDs — it does NOT install the controller.
+
+Security response headers, X-Original-URI, gzip+brotli compression, retries and
+3600s timeouts are applied unconditionally here (the nginx path bakes the
+equivalents into its Ingress annotations).
+
+  Core/GA (gateway.networking.k8s.io/v1): Gateway, HTTPRoute, TLS Terminate,
+    RequestRedirect, Request/ResponseHeaderModifier, HTTPRoute.timeouts.
+  EXPERIMENTAL (gateway.envoyproxy.io/v1alpha1): BackendTrafficPolicy,
+    SecurityPolicy, EnvoyProxy — VALIDATE on a live Envoy Gateway >= v1.8.
+
+See docs/gateway-migration.md for the full nginx->EG migration matrix.
+=============================================================================
+*/}}
+
+{{/* Mutual exclusion: pick exactly one ingress path. */}}
+{{- if and .Values.ingress.enabled .Values.gateway.enabled }}
+{{- fail "Enable EITHER ingress.enabled (nginx) OR gateway.enabled (Envoy Gateway), not both. When using Envoy Gateway also set nginx.enabled=false." }}
+{{- end }}
+
+{{- if .Values.gateway.enabled }}
+{{- $host := tpl .Values.global.dnsRecord . }}
+{{- $tlsSecret := required "gateway.tls.secretName is required when gateway.enabled=true." .Values.gateway.tls.secretName }}
+{{- $gwClass := required "gateway.className is required when gateway.enabled=true." .Values.gateway.className }}
+{{- $apiSvc := printf "%s-api-service" .Release.Name }}
+{{- $frontendSvc := printf "%s-frontend-service" .Release.Name }}
+{{- $apiPort := .Values.controlplane.ingress.servicePort | int }}
+{{- $frontendPort := .Values.frontend.ingress.servicePort | int }}
+{{- $timeout := "3600s" }}
+{{- $apiReq := mul (.Values.gateway.rateLimit.requestsPerSecond | int) (.Values.gateway.rateLimit.burstMultiplier | int) }}
+{{- $frontendReq := mul (.Values.gateway.rateLimit.frontendRequestsPerSecond | int) (.Values.gateway.rateLimit.burstMultiplier | int) }}
+---
+# Gateway — HTTPS listener (TLS terminate, BYO Secret) + HTTP listener (redirect).
+# Single hostname (global.dnsRecord), so one cert covers both backends.
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: {{ .Release.Name }}-gateway
+  labels:
+    app: {{ .Release.Name }}-gateway
+spec:
+  gatewayClassName: {{ $gwClass | quote }}
+  # Attach the chart-managed EnvoyProxy that schedules/scales the data-plane pods.
+  infrastructure:
+    parametersRef:
+      group: gateway.envoyproxy.io
+      kind: EnvoyProxy
+      name: {{ .Release.Name }}-proxy
+  listeners:
+    - name: https
+      protocol: HTTPS
+      port: 443
+      hostname: {{ $host | quote }}
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            name: {{ $tlsSecret | quote }}
+      allowedRoutes:
+        namespaces:
+          from: Same
+    - name: http
+      protocol: HTTP
+      port: 80
+      hostname: {{ $host | quote }}
+      allowedRoutes:
+        namespaces:
+          from: Same
+---
+# API HTTPRoute. Rule order is load-bearing: the streaming-download regex is
+# rule[0] so it matches BEFORE the broad /api prefix (within-route ties resolve to
+# the first matching rule — Gateway API does NOT guarantee cross-route regex
+# precedence, so both api rules live in ONE HTTPRoute). Both rules -> API backend.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ .Release.Name }}-api
+  labels:
+    app: {{ .Release.Name }}-gateway
+spec:
+  parentRefs:
+    - name: {{ .Release.Name }}-gateway
+      sectionName: https
+  hostnames:
+    - {{ $host | quote }}
+  rules:
+    # rule[0] — streaming source-record download (nginx priority 100).
+    - matches:
+        - path:
+            type: RegularExpression
+            value: "/api/anomalies/[0-9]+/source-record/download.*"
+      filters:
+        {{- include "qualytics.gateway.routeFilters" . | nindent 8 }}
+      timeouts:
+        request: {{ $timeout | quote }}
+        backendRequest: {{ $timeout | quote }}
+      backendRefs:
+        - name: {{ $apiSvc }}
+          port: {{ $apiPort }}
+    # rule[1] — regular API (nginx priority 10).
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /api
+      filters:
+        {{- include "qualytics.gateway.routeFilters" . | nindent 8 }}
+      timeouts:
+        request: {{ $timeout | quote }}
+        backendRequest: {{ $timeout | quote }}
+      backendRefs:
+        - name: {{ $apiSvc }}
+          port: {{ $apiPort }}
+---
+# Frontend HTTPRoute. rule[0] /.well-known -> API backend (nginx serves it from the
+# frontend ingress but proxies to the API; it keeps the FRONTEND rate-limit policy,
+# not the api one). rule[1] catch-all -> frontend.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ .Release.Name }}-frontend
+  labels:
+    app: {{ .Release.Name }}-gateway
+spec:
+  parentRefs:
+    - name: {{ .Release.Name }}-gateway
+      sectionName: https
+  hostnames:
+    - {{ $host | quote }}
+  rules:
+    # rule[0] — /.well-known/* -> API backend (auth/OIDC discovery).
+    - matches:
+        - path:
+            type: RegularExpression
+            value: "/\\.well-known.*"
+      filters:
+        {{- include "qualytics.gateway.routeFilters" . | nindent 8 }}
+      timeouts:
+        request: {{ $timeout | quote }}
+        backendRequest: {{ $timeout | quote }}
+      backendRefs:
+        - name: {{ $apiSvc }}
+          port: {{ $apiPort }}
+    # rule[1] — catch-all -> frontend (identity path, no rewrite needed).
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      filters:
+        {{- include "qualytics.gateway.routeFilters" . | nindent 8 }}
+      timeouts:
+        request: {{ $timeout | quote }}
+        backendRequest: {{ $timeout | quote }}
+      backendRefs:
+        - name: {{ $frontendSvc }}
+          port: {{ $frontendPort }}
+---
+# HTTP->HTTPS redirect (nginx force-ssl-redirect). Attaches to the :80 listener; no
+# backendRefs. statusCode default 301 (Gateway API core guarantees 301/302).
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ .Release.Name }}-redirect
+  labels:
+    app: {{ .Release.Name }}-gateway
+spec:
+  parentRefs:
+    - name: {{ .Release.Name }}-gateway
+      sectionName: http
+  hostnames:
+    - {{ $host | quote }}
+  rules:
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            statusCode: {{ .Values.gateway.httpsRedirectCode | int }}
+{{/*
+  BackendTrafficPolicy (EXPERIMENTAL v1alpha1) — one per HTTPRoute so the API
+  (50 rps) and frontend (500 rps) rate limits differ. Carries retry + upstream
+  timeouts (+ rate limit when enabled). Passive ejection is intentionally OMITTED
+  (off by default in EG) to reproduce nginx upstream-max-fails:0.
+*/}}
+{{- range $route := list (dict "name" (printf "%s-api" .Release.Name) "requests" $apiReq) (dict "name" (printf "%s-frontend" .Release.Name) "requests" $frontendReq) }}
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: BackendTrafficPolicy
+metadata:
+  name: {{ $route.name }}
+  labels:
+    app: {{ $.Release.Name }}-gateway
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: {{ $route.name }}
+  # nginx proxy-next-upstream "error timeout http_503", tries 3.
+  retry:
+    numRetries: 3
+    retryOn:
+      triggers:
+        - connect-failure
+        - reset
+      httpStatusCodes:
+        - 503
+    perRetry:
+      timeout: {{ $timeout | quote }}
+  # nginx proxy-connect/read/send 3600s -> connect + idle timeouts.
+  timeout:
+    tcp:
+      connectTimeout: {{ $timeout | quote }}
+    http:
+      connectionIdleTimeout: {{ $timeout | quote }}
+  # gzip + brotli, negotiated by Accept-Encoding (no content-type allow-list in EG).
+  compression:
+    - type: Gzip
+      gzip: {}
+    - type: Brotli
+      brotli: {}
+  {{- if $.Values.gateway.rateLimit.enabled }}
+  # Per-IP request rate limit (burst folded into the count; Envoy has no burst-queue
+  # knob). 429 on overflow (Envoy fixed code, matches nginx).
+  rateLimit:
+    {{- if eq $.Values.gateway.rateLimit.type "global" }}
+    # Global = true per-source-IP (sourceCIDR Distinct); REQUIRES the controller's
+    # Redis rate-limit service or the policy stays unprogrammed.
+    type: Global
+    global:
+      rules:
+        - clientSelectors:
+            - sourceCIDR:
+                value: 0.0.0.0/0
+                type: Distinct
+          limit:
+            requests: {{ $route.requests }}
+            unit: Second
+    {{- else }}
+    # Local = zero infra, per-Envoy-pod bucket (effective ceiling = requests x proxy replicas).
+    type: Local
+    local:
+      rules:
+        - limit:
+            requests: {{ $route.requests }}
+            unit: Second
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- if .Values.gateway.cors }}
+---
+# CORS (EXPERIMENTAL v1alpha1) — gated on gateway.cors. Attaches to the Gateway so
+# it applies to every route. allowOrigins "*" => never set allowCredentials true.
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: {{ .Release.Name }}-cors
+  labels:
+    app: {{ .Release.Name }}-gateway
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: {{ .Release.Name }}-gateway
+  cors:
+    allowOrigins:
+      - "*"
+    allowMethods:
+      - GET
+      - POST
+      - PUT
+      - PATCH
+      - OPTIONS
+      - HEAD
+      - DELETE
+{{- end }}
+---
+# EnvoyProxy (EXPERIMENTAL v1alpha1) — schedules/scales the data-plane Envoy pods
+# (the pods serving traffic). Attached to the Gateway via infrastructure.parametersRef
+# above. Mirrors the nginx controller's nodeSelector/tolerations/replicas.
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: EnvoyProxy
+metadata:
+  name: {{ .Release.Name }}-proxy
+  labels:
+    app: {{ .Release.Name }}-gateway
+spec:
+  provider:
+    type: Kubernetes
+    kubernetes:
+      envoyDeployment:
+        replicas: {{ .Values.gateway.proxy.replicas | int }}
+        {{- if or .Values.gateway.proxy.nodeSelector .Values.gateway.proxy.tolerations }}
+        pod:
+          {{- if .Values.gateway.proxy.nodeSelector }}
+          nodeSelector:
+            {{- toYaml .Values.gateway.proxy.nodeSelector | nindent 12 }}
+          {{- end }}
+          {{- if .Values.gateway.proxy.tolerations }}
+          tolerations:
+            {{- toYaml .Values.gateway.proxy.tolerations | nindent 12 }}
+          {{- end }}
+        {{- end }}
+{{- end }}

--- a/charts/qualytics/templates/ingress.yaml
+++ b/charts/qualytics/templates/ingress.yaml
@@ -31,29 +31,6 @@ nginx.ingress.kubernetes.io/configuration-snippet: |
 {{- end -}}
 
 
-{{/* Define ModSecurity snippet as a named template */}}
-{{- define "common.modsecurity.snippet" -}}
-# Enable prevention mode. Can be any of: DetectionOnly,On,Off (default is DetectionOnly)
-SecRuleEngine On
-SecRequestBodyAccess On
-# Update config to include PUT/PATCH/DELETE in the allowed HTTP methods
-SecAction "id:900200,phase:1,nolog,pass,t:none,\
-  setvar:tx.allowed_methods=GET HEAD POST OPTIONS PUT PATCH DELETE"
-# Send ModSecurity audit logs to the stdout (only for rejected requests)
-SecAuditLog /dev/stdout
-SecAuditLogParts ABCIJDEFHZ
-SecAuditLogFormat JSON
-SecAuditEngine RelevantOnly # could be On/Off/RelevantOnly
-# addresses SC-14854 expanded (phase:1 to reject before body processing)
-SecRule REQUEST_URI_RAW "@rx (?:/\?){3,}" "id:14854,phase:1,deny,status:403"
-# Block absurdly long URIs used in DDoS path-traversal floods (>4KB).
-# t:length must run before @gt so the numeric comparison is against the URI
-# character count, otherwise @gt coerces the raw string to int (=0) and never fires.
-SecRule REQUEST_URI_RAW "@gt 4096" "id:14855,phase:1,deny,status:414,t:length"
-# addresses SC-15205
-SecRuleRemoveById 949110
-{{- end -}}
-
 {{- if ( eq .Values.ingress.enabled true ) }}
 {{/*
   Resolve TLS Secret names with three-tier precedence:

--- a/charts/qualytics/tests/gateway_test.yaml
+++ b/charts/qualytics/tests/gateway_test.yaml
@@ -1,0 +1,355 @@
+suite: test envoy gateway resources
+templates:
+  - gateway.yaml
+tests:
+  - it: should not render any gateway resources when disabled
+    set:
+      gateway.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should fail when both ingress and gateway are enabled (mutual exclusion)
+    set:
+      ingress.enabled: true
+      gateway.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "Enable EITHER ingress.enabled (nginx) OR gateway.enabled (Envoy Gateway), not both. When using Envoy Gateway also set nginx.enabled=false."
+
+  - it: should fail when className is empty
+    set:
+      gateway.enabled: true
+      gateway.className: ""
+    asserts:
+      - failedTemplate:
+          errorMessage: "gateway.className is required when gateway.enabled=true."
+
+  - it: should fail when tls.secretName is empty
+    set:
+      gateway.enabled: true
+      gateway.tls.secretName: ""
+    asserts:
+      - failedTemplate:
+          errorMessage: "gateway.tls.secretName is required when gateway.enabled=true."
+
+  - it: should render the core gateway resources when enabled
+    set:
+      gateway.enabled: true
+      global.dnsRecord: "test.qualytics.io"
+    asserts:
+      # Gateway + 3 HTTPRoutes + 2 BackendTrafficPolicy + EnvoyProxy
+      # (no GatewayClass/CORS by default)
+      - hasDocuments:
+          count: 7
+      - isKind:
+          of: Gateway
+        documentIndex: 0
+      - isKind:
+          of: HTTPRoute
+        documentIndex: 1
+      - isKind:
+          of: HTTPRoute
+        documentIndex: 2
+      - isKind:
+          of: HTTPRoute
+        documentIndex: 3
+      - isKind:
+          of: BackendTrafficPolicy
+        documentIndex: 4
+      - isKind:
+          of: BackendTrafficPolicy
+        documentIndex: 5
+      - isKind:
+          of: EnvoyProxy
+        documentIndex: 6
+
+  - it: should configure the Gateway with class, hostname and TLS terminate
+    set:
+      gateway.enabled: true
+      global.dnsRecord: "test.qualytics.io"
+    asserts:
+      - equal:
+          path: spec.gatewayClassName
+          value: eg                 # default className
+        documentIndex: 0
+      - equal:
+          path: spec.listeners[0].protocol
+          value: HTTPS
+        documentIndex: 0
+      - equal:
+          path: spec.listeners[0].port
+          value: 443
+        documentIndex: 0
+      - equal:
+          path: spec.listeners[0].tls.mode
+          value: Terminate
+        documentIndex: 0
+      - equal:
+          path: spec.listeners[0].hostname
+          value: "test.qualytics.io"
+        documentIndex: 0
+      - equal:
+          path: spec.listeners[1].protocol
+          value: HTTP
+        documentIndex: 0
+      # data-plane EnvoyProxy is wired via infrastructure.parametersRef
+      - equal:
+          path: spec.infrastructure.parametersRef.kind
+          value: EnvoyProxy
+        documentIndex: 0
+
+  - it: should default the TLS Secret to qualytics-tls-cert and allow override
+    set:
+      gateway.enabled: true
+      global.dnsRecord: "test.qualytics.io"
+    asserts:
+      - equal:
+          path: spec.listeners[0].tls.certificateRefs[0].name
+          value: "qualytics-tls-cert"
+        documentIndex: 0
+
+  - it: should use a custom gateway.tls.secretName when set
+    set:
+      gateway.enabled: true
+      gateway.tls.secretName: "my-cert"
+      global.dnsRecord: "test.qualytics.io"
+    asserts:
+      - equal:
+          path: spec.listeners[0].tls.certificateRefs[0].name
+          value: "my-cert"
+        documentIndex: 0
+
+  - it: should order the streaming regex rule before the broad /api prefix rule
+    set:
+      gateway.enabled: true
+      global.dnsRecord: "test.qualytics.io"
+    asserts:
+      - equal:
+          path: metadata.name
+          value: "RELEASE-NAME-api"
+        documentIndex: 1
+      - equal:
+          path: spec.rules[0].matches[0].path.type
+          value: RegularExpression
+        documentIndex: 1
+      - equal:
+          path: spec.rules[0].matches[0].path.value
+          value: "/api/anomalies/[0-9]+/source-record/download.*"
+        documentIndex: 1
+      - equal:
+          path: spec.rules[1].matches[0].path.type
+          value: PathPrefix
+        documentIndex: 1
+      - equal:
+          path: spec.rules[1].matches[0].path.value
+          value: "/api"
+        documentIndex: 1
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: "RELEASE-NAME-api-service"
+        documentIndex: 1
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 8000
+        documentIndex: 1
+
+  - it: should keep /.well-known on the frontend route but pointed at the API backend
+    # nginx parity: well-known is on the frontend ingress (500 rps policy) yet
+    # proxies to the API. Moving it under the api route would drop it to 50 rps.
+    set:
+      gateway.enabled: true
+      global.dnsRecord: "test.qualytics.io"
+    asserts:
+      - equal:
+          path: metadata.name
+          value: "RELEASE-NAME-frontend"
+        documentIndex: 2
+      - equal:
+          path: spec.rules[0].matches[0].path.type
+          value: RegularExpression
+        documentIndex: 2
+      - equal:
+          path: spec.rules[0].matches[0].path.value
+          value: "/\\.well-known.*"
+        documentIndex: 2
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: "RELEASE-NAME-api-service"
+        documentIndex: 2
+      - equal:
+          path: spec.rules[1].matches[0].path.value
+          value: "/"
+        documentIndex: 2
+      - equal:
+          path: spec.rules[1].backendRefs[0].name
+          value: "RELEASE-NAME-frontend-service"
+        documentIndex: 2
+      - equal:
+          path: spec.rules[1].backendRefs[0].port
+          value: 8080
+        documentIndex: 2
+
+  - it: should always emit the security response headers and X-Original-URI on each rule
+    set:
+      gateway.enabled: true
+      global.dnsRecord: "test.qualytics.io"
+    asserts:
+      - equal:
+          path: spec.rules[0].filters[0].type
+          value: ResponseHeaderModifier
+        documentIndex: 1
+      - equal:
+          path: spec.rules[0].filters[0].responseHeaderModifier.set[3].name
+          value: Strict-Transport-Security
+        documentIndex: 1
+      - equal:
+          path: spec.rules[0].filters[0].responseHeaderModifier.set[3].value
+          value: "max-age=31536000; includeSubDomains; preload"
+        documentIndex: 1
+      - equal:
+          path: spec.rules[0].filters[1].type
+          value: RequestHeaderModifier
+        documentIndex: 1
+      - equal:
+          path: spec.rules[0].filters[1].requestHeaderModifier.set[0].name
+          value: X-Original-URI
+        documentIndex: 1
+
+  - it: should default the HTTP->HTTPS redirect to status 301
+    set:
+      gateway.enabled: true
+      global.dnsRecord: "test.qualytics.io"
+    asserts:
+      - equal:
+          path: spec.rules[0].filters[0].type
+          value: RequestRedirect
+        documentIndex: 3
+      - equal:
+          path: spec.rules[0].filters[0].requestRedirect.scheme
+          value: https
+        documentIndex: 3
+      - equal:
+          path: spec.rules[0].filters[0].requestRedirect.statusCode
+          value: 301
+        documentIndex: 3
+
+  - it: should allow overriding the redirect status code
+    set:
+      gateway.enabled: true
+      gateway.httpsRedirectCode: 308
+      global.dnsRecord: "test.qualytics.io"
+    asserts:
+      - equal:
+          path: spec.rules[0].filters[0].requestRedirect.statusCode
+          value: 308
+        documentIndex: 3
+
+  - it: should set api rate limit to rps*burst and frontend to its own, never eject
+    set:
+      gateway.enabled: true
+      global.dnsRecord: "test.qualytics.io"
+    asserts:
+      - equal:
+          path: metadata.name
+          value: "RELEASE-NAME-api"
+        documentIndex: 4
+      - equal:
+          path: spec.rateLimit.type
+          value: Local
+        documentIndex: 4
+      - equal:
+          path: spec.rateLimit.local.rules[0].limit.requests
+          value: 250                # 50 rps * 5 burst
+        documentIndex: 4
+      - equal:
+          path: spec.retry.numRetries
+          value: 3
+        documentIndex: 4
+      - contains:
+          path: spec.retry.retryOn.httpStatusCodes
+          content: 503
+        documentIndex: 4
+      # never passively eject (nginx upstream-max-fails:0) — no passive health check
+      - notExists:
+          path: spec.healthCheck
+        documentIndex: 4
+      - equal:
+          path: spec.rateLimit.local.rules[0].limit.requests
+          value: 2500               # 500 rps * 5 burst
+        documentIndex: 5
+
+  - it: should use global per-IP rate limiting when type=global
+    set:
+      gateway.enabled: true
+      gateway.rateLimit.type: global
+      global.dnsRecord: "test.qualytics.io"
+    asserts:
+      - equal:
+          path: spec.rateLimit.type
+          value: Global
+        documentIndex: 4
+      - equal:
+          path: spec.rateLimit.global.rules[0].clientSelectors[0].sourceCIDR.type
+          value: Distinct
+        documentIndex: 4
+
+  - it: should always render the data-plane EnvoyProxy with 1 replica by default
+    set:
+      gateway.enabled: true
+      global.dnsRecord: "test.qualytics.io"
+    asserts:
+      - isKind:
+          of: EnvoyProxy
+        documentIndex: 6
+      - equal:
+          path: spec.provider.kubernetes.envoyDeployment.replicas
+          value: 1
+        documentIndex: 6
+      # With empty nodeSelector/tolerations, `pod:` must be OMITTED (a null `pod`
+      # fails the EnvoyProxy CRD's server-side schema validation).
+      - notExists:
+          path: spec.provider.kubernetes.envoyDeployment.pod
+        documentIndex: 6
+
+  - it: should schedule the data-plane Envoy pods via proxy.nodeSelector
+    set:
+      gateway.enabled: true
+      gateway.proxy.nodeSelector:
+        appNodes: "true"
+      global.dnsRecord: "test.qualytics.io"
+    asserts:
+      - equal:
+          path: spec.provider.kubernetes.envoyDeployment.pod.nodeSelector.appNodes
+          value: "true"
+        documentIndex: 6
+
+  - it: should reference (not create) the GatewayClass via gatewayClassName
+    # The chart never renders a GatewayClass (it's a cluster prerequisite); the
+    # core-resources test above already asserts the doc set is exactly 7 with no
+    # GatewayClass. Here we just confirm the Gateway references the configured class.
+    set:
+      gateway.enabled: true
+      gateway.className: my-eg
+      global.dnsRecord: "test.qualytics.io"
+    asserts:
+      - equal:
+          path: spec.gatewayClassName
+          value: my-eg
+        documentIndex: 0
+
+  - it: should render a CORS SecurityPolicy only when gateway.cors is true
+    set:
+      gateway.enabled: true
+      gateway.cors: true
+      global.dnsRecord: "test.qualytics.io"
+    asserts:
+      - hasDocuments:
+          count: 8
+      - isKind:
+          of: SecurityPolicy
+        documentIndex: 6
+      - contains:
+          path: spec.cors.allowOrigins
+          content: "*"
+        documentIndex: 6

--- a/charts/qualytics/values.yaml
+++ b/charts/qualytics/values.yaml
@@ -35,9 +35,6 @@ nginx:
       #   service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: 'true'
       #   service.beta.kubernetes.io/aws-load-balancer-type: nlb
 
-#--------------------------------------------------------------------------------
-# App Ingresses
-#--------------------------------------------------------------------------------
 ingress:
   enabled: false
   cors: false
@@ -66,6 +63,51 @@ ingress:
     # keep working without any values changes.
     apiSecretName: "api-tls-cert"
     frontendSecretName: "frontend-tls-cert"
+
+#--------------------------------------------------------------------------------
+# Envoy Gateway routing (Gateway API) — the `ingress` equivalent. Pick ONE path:
+# `ingress` (nginx) OR `gateway`.
+#--------------------------------------------------------------------------------
+# PREREQUISITE: the Envoy Gateway controller + its CRDs + the GatewayClass must
+# already exist on the cluster (Helm can't install CRDs and use them in one release).
+# Install gateway-helm separately — e.g. a Terraform add-on on a dedicated cluster.
+# See docs/gateway-migration.md.
+#
+# Self-contained: does NOT reuse any ingress.* / nginx.* values (nginx is removed
+# once all customers migrate). Renders the Gateway, HTTPRoutes and Envoy Gateway
+# policies. Security headers, gzip+brotli compression, X-Original-URI, retries and
+# 3600s timeouts are applied automatically (same as the nginx path bakes them into
+# annotations). Needs Envoy Gateway >= v1.8.
+gateway:
+  enabled: false
+  # Existing GatewayClass to attach to (created with the controller; default "eg").
+  className: eg
+  # TLS — Bring Your Own. Create this kubernetes.io/tls Secret before installing.
+  tls:
+    secretName: qualytics-tls-cert
+  # CORS for the API (off by default).
+  cors: false
+  # HTTP->HTTPS redirect status. Gateway API allows 301/302 only (nginx used 308).
+  httpsRedirectCode: 301
+  # Per-IP request rate limiting (429 on overflow).
+  rateLimit:
+    enabled: true
+    # local  = per-Envoy-pod bucket, no extra infra.
+    # global = true per-source-IP, but needs the controller's Redis rate-limit service.
+    type: local
+    requestsPerSecond: 50            # API routes
+    frontendRequestsPerSecond: 500   # frontend (parallel asset loads)
+    burstMultiplier: 5               # burst bucket = rps * multiplier
+  # Data-plane Envoy proxy pods (the pods serving traffic, via the EnvoyProxy CRD).
+  proxy:
+    replicas: 1
+    nodeSelector: {}
+    #   appNodes: "true"
+    tolerations: []
+    #   - key: appNodes
+    #     operator: Equal
+    #     value: "true"
+    #     effect: NoSchedule
 
 #--------------------------------------------------------------------------------
 # Global values

--- a/docs/gateway-migration.md
+++ b/docs/gateway-migration.md
@@ -1,0 +1,300 @@
+# Envoy Gateway (Gateway API) ingress — migration guide & coverage report
+
+The chart can expose Qualytics through **Envoy Gateway** (Gateway API) instead of the
+bundled **ingress-nginx**. Both paths are supported side by side so you can switch
+controllers; nginx will eventually be removed in favour of Envoy Gateway.
+
+This page documents:
+1. how to turn it on,
+2. exactly which nginx ingress behaviours migrate (and how),
+3. **what cannot be migrated**, and the workarounds,
+4. the validation you must do on a live controller before production.
+
+---
+
+## Model
+
+- **Controller is a cluster PREREQUISITE — not a chart dependency.** Unlike nginx
+  (whose routing uses the built-in `Ingress` API, so the chart can install the
+  controller as a subchart), Gateway API is **all CRDs**, and Helm cannot install a
+  CRD and a custom resource of it in the same release. So the Envoy Gateway controller
+  + its CRDs + the `GatewayClass` must already exist; install `gateway-helm` separately
+  (e.g. a Terraform add-on on a dedicated cluster — see
+  [Installing the controller](#installing-the-controller)). The chart renders **only**
+  the gateway routing CRs against those pre-existing CRDs.
+- **One path at a time.** `ingress.enabled` (nginx) and `gateway.enabled` are
+  mutually exclusive; enabling both fails the render. Keep `nginx.enabled: false` when
+  using Envoy Gateway so the bundled nginx controller is not installed.
+- **Self-contained config.** The gateway path reads only `gateway.*` — it does **not**
+  reuse any `ingress.*` / `nginx.*` values, so nginx can be removed cleanly once every
+  customer has migrated.
+
+### Versions
+
+| Component | Minimum | Notes |
+|---|---|---|
+| Envoy Gateway | **v1.8** | v1.8.x bundles Gateway API v1.5 / Envoy 1.38. Dynamic-module + Wasm TLS hardening landed in v1.8. |
+| Gateway API | **v1.2** | `HTTPRoute.timeouts` reached the Standard channel in v1.2. |
+| Kubernetes | **1.30** | Existing chart target. (Coraza *DynamicModule* image-volume loading needs 1.35+, so prefer the Wasm WAF path.) |
+
+> The core routing pieces (Gateway, HTTPRoute, TLS Terminate, redirect, header
+> modifiers, timeouts) are **GA / Standard channel**. Every `gateway.envoyproxy.io`
+> policy CRD (BackendTrafficPolicy, SecurityPolicy, EnvoyExtensionPolicy, EnvoyProxy)
+> is **`v1alpha1` (experimental)** — fields can shift between EG releases, so validate
+> against your installed version.
+
+---
+
+## Enable it
+
+**Step 1 — install the controller (prerequisite, once per cluster):** see
+[Installing the controller](#installing-the-controller).
+
+**Step 2 — enable the gateway path in the chart:**
+
+```yaml
+# values.yaml
+ingress:
+  enabled: false          # turn OFF the nginx path
+nginx:
+  enabled: false          # do NOT install the bundled nginx controller
+gateway:
+  enabled: true
+  className: eg           # the EXISTING GatewayClass (created with the controller)
+  tls:
+    secretName: qualytics-tls-cert   # BYO kubernetes.io/tls Secret
+  # optional; defaults shown
+  cors: false
+  httpsRedirectCode: 301
+  rateLimit:
+    enabled: true
+    type: local           # or "global" (needs controller-side Redis RLS)
+```
+
+`gateway.*` is **self-contained** — it does not read any `ingress.*` / `nginx.*`
+values (nginx is removed once everyone migrates). TLS is a BYO `kubernetes.io/tls`
+Secret named by `gateway.tls.secretName` — see [ingress-tls.md](ingress-tls.md).
+Security headers, gzip+brotli compression, X-Original-URI, retries and 3600s
+timeouts are applied automatically (no per-feature toggles, same as the nginx path).
+
+### Resources rendered (`templates/gateway.yaml`)
+
+| Kind | Name | Purpose |
+|---|---|---|
+| `Gateway` | `<release>-gateway` | HTTPS (TLS terminate) + HTTP (redirect) listeners |
+| `HTTPRoute` | `<release>-api` | `/api/anomalies/.../download` (rule 0) + `/api` (rule 1) → API |
+| `HTTPRoute` | `<release>-frontend` | `/.well-known` → API (rule 0) + `/` → frontend (rule 1) |
+| `HTTPRoute` | `<release>-redirect` | HTTP→HTTPS 301 |
+| `BackendTrafficPolicy` | `<release>-api` / `-frontend` | retry, timeouts, rate limit, compression |
+| `EnvoyProxy` | `<release>-proxy` | data-plane Envoy pod scheduling/replicas (always) |
+| `SecurityPolicy` | `<release>-cors` | only when `gateway.cors: true` |
+
+The controller, its CRDs, and the `GatewayClass` are **not** rendered by the chart —
+they are the cluster prerequisite below.
+
+---
+
+## Installing the controller
+
+> **Why this is a separate step (and not a chart dependency).** Helm cannot install a
+> CRD and a custom resource that uses it in the **same release** — a one-shot install
+> that bundled `gateway-helm` and rendered our `Gateway`/`HTTPRoute`/`BackendTrafficPolicy`
+> fails with `ensure CRDs are installed first` (verified on a live cluster). nginx avoids
+> this only because `Ingress` is a built-in API. So the controller + CRDs + `GatewayClass`
+> are a **cluster prerequisite**, installed once, independent of the Qualytics release.
+
+- **Shared cluster** — the controller already runs; do nothing here, just set
+  `gateway.className` to the existing `GatewayClass`.
+- **Dedicated cluster** — install the controller as cluster infrastructure. Two ways:
+
+**(a) Terraform add-on** (recommended for dedicated clusters provisioned via `terraform/`):
+
+```hcl
+resource "helm_release" "envoy_gateway" {
+  name             = "eg"
+  repository       = "oci://docker.io/envoyproxy"
+  chart            = "gateway-helm"
+  version          = "v1.8.1"
+  namespace        = "envoy-gateway-system"
+  create_namespace = true
+}
+
+# gateway-helm ships no GatewayClass — create the one the chart references.
+resource "kubernetes_manifest" "gateway_class" {
+  manifest = {
+    apiVersion = "gateway.networking.k8s.io/v1"
+    kind       = "GatewayClass"
+    metadata   = { name = "eg" }
+    spec       = { controllerName = "gateway.envoyproxy.io/gatewayclass-controller" }
+  }
+  depends_on = [helm_release.envoy_gateway]
+}
+```
+
+**(b) Plain Helm + kubectl** (one-time, e.g. a runbook step):
+
+```bash
+helm install eg oci://docker.io/envoyproxy/gateway-helm --version v1.8.1 \
+  -n envoy-gateway-system --create-namespace --wait
+
+kubectl apply -f - <<'EOF'
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: eg
+spec:
+  controllerName: gateway.envoyproxy.io/gatewayclass-controller
+EOF
+```
+
+Then deploy Qualytics with `gateway.enabled: true` + `gateway.className: eg`.
+
+> ### ⚠️ The controller is a cluster-scoped singleton
+> It owns **cluster-wide** Gateway API + `gateway.envoyproxy.io` CRDs in
+> `envoy-gateway-system`. Don't install a second one where Envoy Gateway / Gateway API
+> CRDs already exist (ownership conflicts), and remember a `helm uninstall eg` removes
+> those CRDs cluster-wide (breaking any other Gateways). EG's CRDs are large — if a
+> plain `helm install` ever fails on CRD size, install the CRDs first via
+> `helm template oci://docker.io/envoyproxy/gateway-crds-helm --version v1.8.1 ... | kubectl apply --server-side -f -`.
+
+---
+
+## Migration matrix
+
+✅ full · 🟡 partial / behavioural delta · ❌ cannot migrate
+
+| nginx behaviour | Status | Envoy Gateway construct |
+|---|---|---|
+| TLS termination, BYO Secret | ✅ | `Gateway` HTTPS listener, `tls.mode: Terminate`, `certificateRefs` |
+| Routing api / well-known / frontend | ✅ | `HTTPRoute` rules + `backendRefs` |
+| Identity rewrite (`rewrite-target /$1`) | ✅ | no filter needed (Gateway API forwards the path unchanged) |
+| 7 security response headers | ✅ | `HTTPRoute` `ResponseHeaderModifier.set` (verbatim values) |
+| Timeouts 3600s | ✅ | `HTTPRoute.timeouts` + `BackendTrafficPolicy.timeout.{tcp,http}` |
+| Retry (`error timeout http_503`, 3 tries) | ✅ | `BackendTrafficPolicy.retry` (`connect-failure`,`reset` + `httpStatusCodes:[503]`) |
+| Never passively eject (`upstream-max-fails:0`) | ✅ | **omit** `healthCheck.passive` (off by default in EG) |
+| `proxy-buffering off` (streaming route) | ✅ | Envoy streams by default (no-op, correct outcome) |
+| HTTP→HTTPS redirect | 🟡 | `RequestRedirect` **301** (Gateway API core only guarantees 301/302; nginx used **308**) |
+| X-Original-URI to upstream | 🟡 | `RequestHeaderModifier` with EG-only `%REQ(...)%` value (non-portable; query-string inclusion needs live check) |
+| gzip + brotli compression | 🟡 | `BackendTrafficPolicy.compression` — **no content-type allow-list** (compresses all above `minContentLength`) |
+| Per-IP request rate limit | 🟡 | `BackendTrafficPolicy.rateLimit` — see [rate limiting](#rate-limiting) caveats |
+| `burst-multiplier` | 🟡 | folded into request count; no burst-queue (shaping differs) |
+| Per-IP **connection** limit (`limit-connections`) | ❌ | no per-source-IP connection counter in EG |
+| ModSecurity / OWASP CRS WAF | ❌ | no native WAF; not rendered by the chart — manual Coraza Wasm add-on (see below) |
+| Body-size limits (20MB / 2.6MB) | ❌ | only via the Coraza WAF add-on (not rendered by the chart) |
+| Compression content-type allow-list | ❌ | not expressible without an `EnvoyPatchPolicy` |
+| Numeric route priority | ❌ | no priority field — rely on rule ordering / match specificity |
+
+---
+
+## What cannot be migrated (and what we did instead)
+
+### 1. Per-IP concurrent connection limit (`limit-connections 250 / 1000`, 503 on breach)
+**Why.** Envoy Gateway has no per-source-IP concurrent-connection counter.
+`ClientTrafficPolicy.connection.connectionLimit` is a **per-proxy/per-listener total**
+(not per IP, not synced across replicas) and attaches to the Gateway, not a route — so
+the distinct 250-vs-1000 caps can't be expressed. `circuitBreaker.maxConnections` caps
+*total upstream* connections, also not per-IP. nginx returns 503; there's no equivalent.
+**What we do.** Drop the connection dimension and lean on per-IP **request** rate limiting,
+which covers the DDoS-floor intent. A blunt total cap via `ClientTrafficPolicy` is possible
+but not rendered by the chart.
+
+### 2. Compression content-type allow-list
+**Why.** EG's `compression` exposes algorithm + `minContentLength` only; there's no
+content-type list. Envoy decides by `Accept-Encoding` + size.
+**What we do.** gzip + brotli are migrated fully; only the 10-item type gate is lost (EG
+compresses everything above `minContentLength`). Strict gating would need an
+`EnvoyPatchPolicy` — out of scope for a render-CRDs-only chart.
+
+### 3. `burst-multiplier` (leaky-bucket burst queue)
+**Why.** EG rate limiting is a fixed-window token bucket (`requests` + `unit`); there is no
+`burst`/`nodelay` queue knob.
+**What we do.** Fold the multiplier into a higher `requests` count (e.g. 50 rps ×5 → 250/s).
+Shaping differs (instantaneous allowance vs nginx's queued delayed requests).
+
+### 4. WAF (ModSecurity / OWASP CRS) + body-size limits
+**Why.** Envoy Gateway ships **no** built-in WAF. Every WAF path is an add-on (Coraza
+via Wasm/DynamicModule, or `SecurityPolicy.extAuth` to an external WAF), all `v1alpha1`,
+needs a BYO artifact, and must be enabled in the controller config. The nginx body-size
+limits (20MB/2.6MB) likewise only exist as Coraza `SecRequestBodyLimit` directives.
+**What we do.** The chart does **not** render a WAF (keeping the gateway spec lean and
+avoiding a half-wired feature with no artifact to point at). To add it, attach your own
+`EnvoyExtensionPolicy` to the `<release>-api` / `<release>-frontend` HTTPRoutes loading a
+Coraza proxy-wasm image, carrying the same SecLang rules as the nginx path (method
+allow-list `900200`, triple-`/?`→403 `14854`, URI>4096→414 `14855`,
+`SecRuleRemoveById 949110`, JSON audit log, body limits). The `common.modsecurity.snippet`
+helper still holds those rules. This is a manual, validate-live integration — not a chart
+toggle. Until then, the gateway path has **no WAF**, a known gap vs the nginx path.
+
+### 5. Portable HTTP→HTTPS **308** redirect
+**Why.** Gateway API core conformance only guarantees `301`/`302`; `307`/`308` are
+*extended* support and not guaranteed across controllers/CRD bundles.
+**What we do.** Default to **301** (permanent). Override with `gateway.httpsRedirectCode: 308`
+if your EG build accepts it (validate). Behavioural delta: 301 may let very old clients
+change method on the redirected request.
+
+### 6. True per-IP rate limit without controller-side Redis
+**Why.** Per-distinct-IP limiting needs `type: Global`, which depends on the Envoy
+Ratelimit service + Redis enabled in the **controller's** config — infrastructure the chart
+does not own. A `Global` policy stays unprogrammed if that's missing.
+**What we do.** Default to `type: local` (zero infra). See caveats below. Set
+`gateway.rateLimit.type: global` only if your controller already has RLS.
+
+---
+
+## Routing precedence (read this)
+
+Gateway API has **no numeric priority** (nginx used `100` vs `10`). Precedence for
+`Exact`/`PathPrefix` is deterministic (longest match wins), but for **`RegularExpression`
+it is implementation-specific** and **not guaranteed across separate HTTPRoutes**.
+
+Mitigation built into the chart: the streaming-download regex and the `/api` prefix are
+**two rules in one `HTTPRoute`** with the regex as **rule 0** — within a single route,
+ties resolve to the first matching rule, so the specific download path is claimed before
+the broad `/api`. The same applies to `/.well-known` (rule 0) vs `/` (rule 1) in the
+frontend route. **Validate actual ordering on EG v1.8.x** (curl the download path and
+confirm it isn't shadowed).
+
+> The streaming route in nginx disabled OWASP CRS for performance. Here it shares the
+> api `HTTPRoute`, so if you attach the WAF it also covers the streaming rule (more secure,
+> slightly slower). To exempt it, split the streaming rule into its own `HTTPRoute` and
+> leave the WAF policy off it.
+
+---
+
+## Rate limiting
+
+| Mode | Per-IP? | Infra | Behaviour |
+|---|---|---|---|
+| `local` (default) | ❌ | none | Per-Envoy-pod token bucket. Effective ceiling = `requests × proxy replica count`. Mirrors nginx's per-controller-replica behaviour. |
+| `global` | ✅ | Redis RLS in controller | True per-source-IP (`sourceCIDR` `Distinct`). |
+
+**Multi-replica caveat (local mode):** a `local` limit of 50 rps with 2 Envoy proxy
+replicas allows up to ~100 rps cluster-wide, and the burst ×5 folding compounds it. If you
+raise `gateway.proxy.replicas`, lower the per-pod `requests` proportionally or switch
+to `global`.
+
+Overflow returns **429** (Envoy's fixed code, matches nginx `limit-req-status-code`).
+
+---
+
+## Validation checklist (before production)
+
+`helm unittest`/`helm template` validate rendering only — the `v1alpha1` policy CRDs and
+route precedence must be checked on a **live Envoy Gateway v1.8.x** controller (minikube is
+fine — see the live-test ritual in CLAUDE.md):
+
+- [ ] `kubectl get gatewayclass <name>` is **Accepted** and the EG controller is running.
+- [ ] Gateway becomes **Programmed**; the two listeners (443/80) are ready.
+- [ ] All three HTTPRoutes report **Accepted** + **ResolvedRefs**.
+- [ ] `curl https://<host>/api/anomalies/1/source-record/download` hits the API (regex rule
+      wins over `/api`); `curl https://<host>/.well-known/x` hits the API; `curl https://<host>/`
+      hits the frontend.
+- [ ] HTTP→HTTPS redirect returns your chosen status (301 default).
+- [ ] Security response headers + `X-Original-URI` are present (and `X-Original-URI` includes
+      the query string when you add `?a=b`).
+- [ ] `BackendTrafficPolicy` reports **Accepted** (rate limit / retry / compression applied).
+      If `type: global`, confirm the controller's Redis RLS is enabled.
+- [ ] `EnvoyProxy` is **Accepted** and the data-plane pods land where expected
+      (`gateway.proxy.nodeSelector`/`tolerations`, `replicas`).
+- [ ] Switching from nginx: delete the orphaned nginx `Ingress` objects (they are helm
+      hook resources and may linger): `kubectl delete ingress -n <ns> -l app.kubernetes.io/instance=<release>` (verify names first).

--- a/template.values.yaml
+++ b/template.values.yaml
@@ -111,6 +111,19 @@ ingress:
     # Leave empty to keep the legacy `api-tls-cert` + `frontend-tls-cert` split pair.
     secretName: "qualytics-tls-cert"
 
+# --- Alternative: Envoy Gateway (Gateway API) instead of nginx ---
+# Expose Qualytics through Gateway API resources instead of nginx. Set
+# ingress.enabled and nginx.enabled to false, then uncomment below.
+#
+# PREREQUISITE: the Envoy Gateway controller + CRDs + GatewayClass must already exist
+# (install gateway-helm separately — e.g. a Terraform add-on on a dedicated cluster).
+# Helm can't install CRDs and use them in one release. See docs/gateway-migration.md.
+# gateway:
+#   enabled: true
+#   className: eg              # the EXISTING GatewayClass
+#   tls:
+#     secretName: qualytics-tls-cert
+
 #--------------------------------------------------------------------------------
 # Controlplane Configuration
 #--------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Adds **Envoy Gateway (Gateway API)** as an alternative ingress path to nginx, gated on `gateway.enabled` (mutually exclusive with `ingress.enabled`). Same app routes/TLS/security posture as the nginx path, expressed as Gateway API + Envoy Gateway resources. Goal: eventually retire nginx in favour of Envoy Gateway.

## Controller is a cluster prerequisite (not a chart dependency)
Unlike nginx — whose routing uses the built-in `Ingress` API, so its controller can be a subchart — **Gateway API is all CRDs, and Helm cannot install a CRD and a custom resource of it in the same release** (verified on minikube: the one-shot bundled install fails with `ensure CRDs are installed first`).

So the Envoy Gateway controller + CRDs + `GatewayClass` are installed **separately**, once per cluster:
- **Dedicated cluster (common):** a Terraform `helm_release` add-on for `gateway-helm` + a `GatewayClass` (ready-to-paste HCL in the docs).
- **Shared cluster:** BYO existing controller; just set `gateway.className`.

The chart renders **only** the routing CRs against the pre-existing CRDs.

## What the chart renders (`templates/gateway.yaml`, when `gateway.enabled`)
`Gateway` (HTTPS-terminate + HTTP-redirect listeners) · 3 `HTTPRoute`s · per-route `BackendTrafficPolicy` (retry / timeouts / rate limit / compression) · `EnvoyProxy` (data-plane scheduling) · `SecurityPolicy` (CORS, opt-in).

- Self-contained `gateway.*` config — **no `ingress.*` / `nginx.*` reuse** (so nginx can be removed cleanly later).
- Streaming-download regex ordered before `/api` within one HTTPRoute (route precedence is only guaranteed within a route).
- `/.well-known` kept on the frontend route's rate-limit policy but pointed at the API backend (nginx parity).
- Security headers, gzip+brotli, `X-Original-URI`, retries, and 3600s timeouts are baked in (like nginx bakes its annotations).

## Validation
- `helm lint` clean; **250/250** `helm unittest` (new `tests/gateway_test.yaml`).
- **End-to-end on minikube + Envoy Gateway v1.8.1**: GatewayClass / both listeners / all HTTPRoutes / both BackendTrafficPolicies **Accepted**, data-plane Envoy **2/2 Running**, live `HTTP→HTTPS 301`. Single `helm install` succeeds once the controller pre-exists.

## Known gaps vs nginx (documented in `docs/gateway-migration.md`)
- **No native WAF** — manual Coraza `EnvoyExtensionPolicy` add-on (the one notable parity gap vs nginx ModSecurity).
- Per-IP **connection** limit, compression content-type allow-list, burst-queue shaping, and portable **308** redirect (defaults to 301) — all called out with rationale.

## Notes for reviewers
- Bumped chart version to `2026.6.30` per the date-based bump-on-change convention.
- `docs/gateway-migration.md` has the full nginx→EG migration matrix, the controller-install guide (Terraform + Helm), and a live-validation checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)