### PR TITLE
QUA-2039: support VITE_QUALYTICS_DISABLE_DOWNLOADS in frontend

### DIFF
--- a/charts/qualytics/Chart.yaml
+++ b/charts/qualytics/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: qualytics
 description: A Helm chart for deploying Qualytics on Kubernetes
 type: application
-version: 2026.6.24
-appVersion: 2026.6.24
+version: 2026.6.30
+appVersion: 2026.6.30
 dependencies:
 - name: ingress-nginx
   version: 4.15.1

--- a/charts/qualytics/Chart.yaml
+++ b/charts/qualytics/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: qualytics
 description: A Helm chart for deploying Qualytics on Kubernetes
 type: application
-version: 2026.6.30
-appVersion: 2026.6.30
+version: 2026.6.24
+appVersion: 2026.6.24
 dependencies:
 - name: ingress-nginx
   version: 4.15.1

--- a/charts/qualytics/templates/frontend.yaml
+++ b/charts/qualytics/templates/frontend.yaml
@@ -63,6 +63,8 @@ spec:
             value: {{ tpl .Values.global.dnsRecord . | quote }}
           - name: VITE_QUALYTICS_API_LOCATION
             value: "https://$(VITE_QUALYTICS_DNS)/api"
+          - name: VITE_QUALYTICS_DISABLE_DOWNLOADS
+            value: {{ .Values.frontend.disableDownloads | quote }}
           {{- if ( eq .Values.global.authType "OIDC" ) }}
           - name: VITE_QUALYTICS_AUTH_PROVIDER
             value: OIDC

--- a/charts/qualytics/tests/frontend_test.yaml
+++ b/charts/qualytics/tests/frontend_test.yaml
@@ -120,6 +120,39 @@ tests:
             value: "AUTH0"
         documentIndex: 0
 
+  - it: should disable downloads by default
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: VITE_QUALYTICS_DISABLE_DOWNLOADS
+            value: "false"
+        documentIndex: 0
+
+  - it: should enable disabling downloads when set
+    set:
+      frontend.disableDownloads: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: VITE_QUALYTICS_DISABLE_DOWNLOADS
+            value: "true"
+        documentIndex: 0
+
+  # Independent of auth type — set for OIDC deployments too
+  - it: should set disable downloads regardless of OIDC auth type
+    set:
+      global.authType: "OIDC"
+      frontend.disableDownloads: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: VITE_QUALYTICS_DISABLE_DOWNLOADS
+            value: "true"
+        documentIndex: 0
+
   # Image pull policy
   - it: should use default image pull policy
     asserts:

--- a/charts/qualytics/values.yaml
+++ b/charts/qualytics/values.yaml
@@ -266,8 +266,6 @@ controlplaneCmd:
 #--------------------------------------------------------------------------------
 frontend:
   replicas: 2
-  # Hide all file-download UI controls (exports, source records, token download).
-  # Maps to VITE_QUALYTICS_DISABLE_DOWNLOADS in the frontend.
   disableDownloads: false
   ingress:
     path: "/?(.*)"

--- a/charts/qualytics/values.yaml
+++ b/charts/qualytics/values.yaml
@@ -266,6 +266,9 @@ controlplaneCmd:
 #--------------------------------------------------------------------------------
 frontend:
   replicas: 2
+  # Hide all file-download UI controls (exports, source records, token download).
+  # Maps to VITE_QUALYTICS_DISABLE_DOWNLOADS in the frontend.
+  disableDownloads: false
   ingress:
     path: "/?(.*)"
     servicePort: "8080"

--- a/template.values.yaml
+++ b/template.values.yaml
@@ -124,6 +124,14 @@ controlplane:
     verifyTLSCertificates: true
 
 #--------------------------------------------------------------------------------
+# Frontend Configuration (OPTIONAL)
+#--------------------------------------------------------------------------------
+frontend:
+  # Set true to hide all file-download UI controls (exports, source records,
+  # token download). Maps to VITE_QUALYTICS_DISABLE_DOWNLOADS.
+  disableDownloads: false
+
+#--------------------------------------------------------------------------------
 # Dataplane configuration
 #--------------------------------------------------------------------------------
 dataplane:

--- a/template.values.yaml
+++ b/template.values.yaml
@@ -124,14 +124,6 @@ controlplane:
     verifyTLSCertificates: true
 
 #--------------------------------------------------------------------------------
-# Frontend Configuration (OPTIONAL)
-#--------------------------------------------------------------------------------
-frontend:
-  # Set true to hide all file-download UI controls (exports, source records,
-  # token download). Maps to VITE_QUALYTICS_DISABLE_DOWNLOADS.
-  disableDownloads: false
-
-#--------------------------------------------------------------------------------
 # Dataplane configuration
 #--------------------------------------------------------------------------------
 dataplane:


### PR DESCRIPTION
## Summary
Wires the frontend's `VITE_QUALYTICS_DISABLE_DOWNLOADS` feature flag through the chart so operators can hide all file-download UI controls (exports, source records, token download). Requested by EWS.

The frontend already consumes this env var (via `config.js` generation → `src/consts/env.ts`); this PR just lets the chart set it.

## Changes
- `charts/qualytics/values.yaml` — new `frontend.disableDownloads` (default `false`, preserves current behavior)
- `charts/qualytics/templates/frontend.yaml` — renders `VITE_QUALYTICS_DISABLE_DOWNLOADS`, placed **before** the AUTH0/OIDC conditional so it applies to both auth types
- `charts/qualytics/tests/frontend_test.yaml` — default-off, override-on, and OIDC unit tests

`value: {{ .Values.frontend.disableDownloads | quote }}` → renders `"false"`/`"true"`; frontend checks `=== 'true'`.

## Test plan
- `helm unittest charts/qualytics` → **234 pass** (+3 new)
- `helm template` renders correctly for **both AUTH0 and OIDC**: `value: "false"` default, `value: "true"` with `--set frontend.disableDownloads=true`

Linear: https://linear.app/qualytics/issue/QUA-2039

🤖 Generated with [Claude Code](https://claude.com/claude-code)